### PR TITLE
fix: removed all unwraps

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,7 @@ enum Op {
 }
 
 fn main() {
-    print!("Enter your name: ");
-    io::stdout().flush().unwrap();
+    print_flush("Enter your name: ");
 
     match input::line() {
         Ok(name) => println!("Hello, {name}!"),
@@ -29,8 +28,7 @@ fn main() {
         "\n  1. Summation", "\n  2. Subdivision", "\n  3. Multiplication", "\n  4. Division"
     );
 
-    print!("> ");
-    io::stdout().flush().unwrap();
+    print_flush("> ");
     let operation = input::number();
 
     if let Err(e) = operation {
@@ -43,17 +41,24 @@ fn main() {
         2 => handle_operation(Op::Sub),
         3 => handle_operation(Op::Mul),
         4 => handle_operation(Op::Div),
-        op => unreachable!("Unknown operation \"{op}\""),
+        op => eprintln!("Unknown operation \"{op}\""),
+    }
+}
+
+fn print_flush(prompt: &str) {
+    print!("{prompt}");
+
+    if let Err(e) = io::stdout().flush() {
+        eprintln!("Error: {e}");
+        exit(1);
     }
 }
 
 fn numbers_input() -> Result<(i32, i32), input::InvalidInput> {
-    print!("Enter first number: ");
-    io::stdout().flush().unwrap();
+    print_flush("Enter first number: ");
     let x: i32 = input::number()?;
 
-    print!("Enter second number: ");
-    io::stdout().flush().unwrap();
+    print_flush("Enter second number: ");
     let y: i32 = input::number()?;
 
     Ok((x, y))


### PR DESCRIPTION
Removed all this code snippets:
```rust
print!("Enter your name: ");
io::stdout().flush().unwrap();
```

with new function `print_flush()`:
```rust
fn print_flush(prompt: &str) {
    print!("{prompt}");

    if let Err(e) = io::stdout().flush() {
        eprintln!("Error: {e}");
        exit(1);
    }
}
```

And changed unknown operation handling as suggested:
```rust
match operation.unwrap() {
    ...
    op => eprintln!("Unknown operation \"{op}\""),
}
```